### PR TITLE
Replace deprecated URI.decode with CGI.unescape

### DIFF
--- a/lib/distack/urlsign/signer.rb
+++ b/lib/distack/urlsign/signer.rb
@@ -59,7 +59,7 @@ module Distack::URLSign
       rawsig    = OpenSSL::HMAC.digest(digest, @key, chunks.join)
       signature = Base64.urlsafe_encode64(rawsig)
 
-      if secure_compare(signature, URI.decode(q["_signature"]).to_s)
+      if secure_compare(signature, CGI.unescape(q["_signature"]).to_s)
         new_url = url.dup
         new_url.query = original_qs
         new_url


### PR DESCRIPTION
This makes the gem compatible with Ruby 3. The replacement is [recommended](https://github.com/ruby/uri/commit/61c6a47ebf#diff-936b286152b1184cde04f027289d65e633d0f3ee52fdc42cf4eb072c24312e15L117-L118) in the commit that removes `decode` from `URI`.